### PR TITLE
remove unneeded header

### DIFF
--- a/utilities/direct_messages.go
+++ b/utilities/direct_messages.go
@@ -328,7 +328,6 @@ func RegisterHeaders(req *http.Request) *http.Request {
 	req.Header.Set("origin", "discord.com")
 	req.Header.Set("referer", "discord.com/register")
 	req.Header.Set("x-debug-options", "bugReporterEnabled")
-	req.Header.Set("accept-encoding", "gzip, deflate, br")
 	req.Header.Set("accept-language", "en-US,en;q=0.9")
 	req.Header.Set("content-Type", "application/json")
 	// Imitating Discord Desktop Client


### PR DESCRIPTION
The accept-encoding header is automatically set by the http package to "gzip, deflate, br". If you let the http package do it automatically you wont have to decrypt brotli because the http package will do it by itself. 