### PR TITLE
Added basic Raiding Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 dist/
+.idea/

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,18 @@
+raid_settings:
+  individual_delay: 2 # SECONDS
+  rate_limit_delay: 650 #MILISECONDS
+  offset: 650 #MILLISECONDS
+  random_individual_delay: 50 #MILLISECONDS
+  remove_dead_tokens: true
+  stop_dead_tokens: true
+  online_tokens: false
+  duplicate_message: false # ALLOW DUPLICATE MESSAGE WHILE RAIDING
+  watcher_token: "" # TOKEN THAT CAN SEE THE MESSAGE - USED FOR REACTION ADDING
+  invite_link: "" # INVITE LINK FOR ATTACKED SERVER
+  verify_channel_id: "" # COPY THE CHANNEL ID WHERE THE VERIFICATION MESSAGE IS
+  verify_message_id: "" # COPY THE VERIFICATION MESSAGE ID
+  attacked_channel: "" # WHAT CHANNEL SHOULD THE ARMY RAID
+  attacked_server: "" # WHAT SERVER ARE WE RAIDING
 
 direct_message_settings:
   individual_delay: 110
@@ -6,9 +21,9 @@ direct_message_settings:
   max_dms_per_token: 0
   skip_completed: true
   call: false
-  remove_dead_tokens: true 
-  remove_completed_members: true 
-  stop_dead_tokens: true 
+  remove_dead_tokens: true
+  remove_completed_members: true
+  stop_dead_tokens: true
   check_mutual: false
   friend_before_DM: false
   online_tokens: false
@@ -39,7 +54,7 @@ captcha_settings:
   max_captcha_retry_dm: 0
   max_captcha_retry_invite: 3
 
-other_settings: 
+other_settings:
   disable_keep_alives: false
   mode: 0
   constant_cookies: false
@@ -59,15 +74,15 @@ suspicion_avoidance:
 dm_on_react:
   observer_token: ""
   change_name: true
-  change_avatar: true 
+  change_avatar: true
   invite: ""
   server_id: ""
   channel_id: ""
   message_id: ""
   emoji: ""
-  skip_completed: true 
-  skip_failed: true 
-  leave_token_on_ratelimit: true 
+  skip_completed: true
+  skip_failed: true
+  leave_token_on_ratelimit: true
   rotate_tokens: true
   max_anti_raid_queue: 20
   max_dms_per_token: 10

--- a/discord/invite_joiner.go
+++ b/discord/invite_joiner.go
@@ -19,6 +19,14 @@ import (
 )
 
 func LaunchinviteJoiner() {
+	utilities.PrintMenu([]string{"Raid Mode", "Normal Mode"})
+	invitemode := utilities.UserInputInteger("Enter your choice:")
+
+	if invitemode != 1 && invitemode != 2 {
+		utilities.LogErr("Invalid choice")
+		return
+	}
+
 	utilities.PrintMenu([]string{"Single Invite", "Multiple Invites from File"})
 	invitechoice := utilities.UserInputInteger("Enter your choice:")
 	if invitechoice != 1 && invitechoice != 2 {
@@ -68,7 +76,13 @@ func LaunchinviteJoiner() {
 			}
 		}
 
-		invite := utilities.UserInput("Enter your Invite Code or Link:")
+		var invite string
+		promptmsg := "Enter your Invite Code or Link:"
+		if invitemode == 2 {
+			invite = utilities.UserInput(promptmsg)
+		} else {
+			invite = utilities.GetConfigOrInputString(cfg.RaidSettings.InviteLink, promptmsg)
+		}
 		invite = processInvite(invite)
 		threads := utilities.UserInputInteger("Enter number of threads (0 for maximum):")
 
@@ -84,11 +98,20 @@ func LaunchinviteJoiner() {
 		var emoji string
 
 		if verif == 1 {
-			channelid = utilities.UserInput("ID of the channel with verification message")
-
-			msgid = utilities.UserInput("ID of the message with verification reaction")
-			emoji = utilities.UserInput("Enter emoji")
-
+			if invitemode == 1 {
+				channelid = utilities.GetConfigOrInputString(
+					cfg.RaidSettings.VerifyChannelId,
+					"ID of the channel with verification message",
+				)
+				msgid = utilities.GetConfigOrInputString(
+					cfg.RaidSettings.VerifyChannelId,
+					"ID of the message with verification reaction",
+				)
+			} else {
+				channelid = utilities.UserInput("ID of the channel with verification message")
+				msgid = utilities.UserInput("ID of the message with verification reaction")
+			}
+			emoji = utilities.UserInput("Enter verification Emoji")
 		}
 		base := utilities.UserInputInteger("Enter base delay per thread for joining in seconds: ")
 		random := utilities.UserInputInteger("Enter random delay per thread for joining in seconds: ")

--- a/discord/raid_server.go
+++ b/discord/raid_server.go
@@ -1,0 +1,117 @@
+package discord
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/V4NSH4J/discord-mass-dm-GO/instance"
+	"github.com/V4NSH4J/discord-mass-dm-GO/utilities"
+)
+
+func LaunchRaidServer() {
+	cfg, instances, err := instance.GetEverything()
+	if err != nil {
+		utilities.LogErr("Error while getting config or instances%s", err)
+		return
+	}
+	server := utilities.GetConfigOrInputString(
+		cfg.RaidSettings.AttackedServer,
+		"Enter server ID to perform the raid on: ",
+	)
+	channel := utilities.GetConfigOrInputString(
+		cfg.RaidSettings.AttackedChannel,
+		"Enter the channel ID to attack: ",
+	)
+	// USE MESSAGES JSON
+	var msg instance.Message
+	messagechoice := utilities.UserInputInteger("Enter 1 to use message from file (message.json), 2 to use message from console: ")
+	if messagechoice != 1 && messagechoice != 2 {
+		utilities.LogErr("Invalid choice")
+		return
+	}
+	if messagechoice == 2 {
+		text := utilities.UserInput("Enter your message, use \\n for changing lines. You can also set a constant message in message.json")
+		msg.Content = text
+		msg.Content = strings.Replace(msg.Content, "\\n", "\n", -1)
+		var msgs []instance.Message
+		msgs = append(msgs, msg)
+		err := instance.SetMessages(instances, msgs)
+		if err != nil {
+			utilities.LogErr("Error while setting messages: %s", err)
+			return
+		}
+	} else {
+		var msgs []instance.Message
+		err := instance.SetMessages(instances, msgs)
+		if err != nil {
+			utilities.LogErr("Error while setting messages: %s", err)
+			return
+		}
+	}
+
+	var sentMessages []int
+
+	// START CONCURRENCY
+	var wg sync.WaitGroup
+	wg.Add(len(instances))
+
+	for i := 0; i < len(instances); i++ {
+		// Don't sleep the first one
+		if i != 0 {
+			time.Sleep(time.Duration(cfg.RaidSettings.Offset) * time.Millisecond)
+		}
+		go func(i int) {
+			defer wg.Done()
+
+			index := rand.Intn(len(instances[i].Messages))
+
+			if cfg.RaidSettings.DuplicateMessage == false {
+				if len(sentMessages) < len(instances[i].Messages) {
+					for utilities.ContainsInt(sentMessages, index) {
+						index = rand.Intn(len(instances[i].Messages))
+					}
+				} else {
+					utilities.LogWarn("Token %v will send a duplicate message.", instances[i].Token)
+				}
+			}
+
+			if !utilities.ContainsInt(sentMessages, index) {
+				sentMessages = append(sentMessages, index)
+			}
+
+			if cfg.RaidSettings.OnlineTokens && instances[i].Ws == nil {
+				err := instances[i].StartWS()
+				if err != nil {
+					utilities.LogFailed("Token %v error while going online: %v", instances[i].Token, err)
+				}
+			}
+
+			respCode, body, err := instances[i].SendMessageToChannel(index, utilities.SnowflakeParams{ChannelId: channel, ServerId: server})
+			if err != nil {
+				utilities.LogErr("Token %v error while sending message %s", instances[i].Token, err)
+			}
+			if respCode == 200 {
+				utilities.LogSuccess("Token %v raided channel: %v", instances[i].Token, channel)
+			} else {
+				utilities.LogFailed("Token %v failed to raid channel: %v [%v]", instances[i].Token, channel, string(body))
+			}
+			if cfg.RaidSettings.RandomIndividualDelay != 0 {
+				var sleepTime = rand.Intn(cfg.RaidSettings.RandomIndividualDelay)
+				//utilities.LogInfo("Next token will type in %v milliseconds", sleepTime)
+				time.Sleep(time.Duration(sleepTime) * time.Millisecond)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if cfg.RaidSettings.OnlineTokens {
+		for i := 0; i < len(instances); i++ {
+			if instances[i].Ws != nil {
+				instances[i].Ws.Close()
+			}
+		}
+	}
+	utilities.LogSuccess("All threads finished")
+}

--- a/discord/reaction_adder.go
+++ b/discord/reaction_adder.go
@@ -21,8 +21,24 @@ import (
 )
 
 func LaunchReactionAdder() {
-	utilities.PrintMenu([]string{"From Message", "Manually"})
-	choice := utilities.UserInputInteger("Select an option: ")
+	utilities.PrintMenu([]string{"Verify mode", "Raid mode", "Normal mode"})
+	rxnmode := utilities.UserInputInteger("Select an option:")
+	if rxnmode != 1 && rxnmode != 2 && rxnmode != 3 {
+		utilities.LogErr("Invalid option")
+		return
+	}
+	var choice int
+
+	switch rxnmode {
+	case 1:
+		choice = 1
+	case 2:
+		choice = 1
+	default:
+		utilities.PrintMenu([]string{"From Message", "Manually"})
+		choice = utilities.UserInputInteger("Select an option: ")
+	}
+
 	if choice != 1 && choice != 2 {
 		utilities.LogErr("Invalid option")
 		return
@@ -81,9 +97,40 @@ func LaunchReactionAdder() {
 	var wg sync.WaitGroup
 	wg.Add(len(instances))
 	if choice == 1 {
-		token := utilities.UserInput("Enter a token which can see the message: ")
-		id := utilities.UserInput("Enter the message ID: ")
-		channel := utilities.UserInput("Enter the channel ID: ")
+		var token string
+		var channel string
+		var id string
+
+		switch rxnmode {
+		case 1:
+			token = utilities.GetConfigOrInputString(
+				cfg.RaidSettings.WatcherToken,
+				"Enter a token which can see the message: ",
+			)
+			channel = utilities.GetConfigOrInputString(
+				cfg.RaidSettings.VerifyChannelId,
+				"Enter verification channel ID:",
+			)
+			id = utilities.GetConfigOrInputString(
+				cfg.RaidSettings.VerifyMessageId,
+				"Enter verification message ID: ",
+			)
+		case 2:
+			token = utilities.GetConfigOrInputString(
+				cfg.RaidSettings.WatcherToken,
+				"Enter a token which can see the message: ",
+			)
+			channel = utilities.GetConfigOrInputString(
+				cfg.RaidSettings.AttackedChannel,
+				"Enter raid channel ID:",
+			)
+			id = utilities.UserInput("Enter the final message ID: ")
+		default:
+			token = utilities.UserInput("Enter a token which can see the message: ")
+			channel = utilities.UserInput("Enter channel ID:")
+			id = utilities.UserInput("Enter the message ID: ")
+		}
+
 		msg, err := instance.GetRxn(channel, id, token)
 		if err != nil {
 			utilities.LogErr("Error while getting message %s", err)
@@ -106,7 +153,7 @@ func LaunchReactionAdder() {
 		utilities.PrintMenu2(selection)
 
 		var emojis []int
-		x := utilities.UserInput("Select Emoji, seperate them by commas to select multiple:")
+		x := utilities.UserInput("Select Emoji, separate them by commas to select multiple (ex: 0,1,2):")
 		if !strings.Contains(x, ",") {
 			index, err := strconv.Atoi(x)
 			if err != nil {

--- a/instance/config.go
+++ b/instance/config.go
@@ -19,6 +19,7 @@ import (
 )
 
 type Config struct {
+	RaidSettings       RaidSettings       `yaml:"raid_settings"`
 	DirectMessage      DirectMessage      `yaml:"direct_message_settings"`
 	ProxySettings      ProxySettings      `yaml:"proxy_settings"`
 	ScraperSettings    ScraperSettings    `yaml:"scraper_settings"`
@@ -26,6 +27,22 @@ type Config struct {
 	OtherSettings      OtherSettings      `yaml:"other_settings"`
 	SuspicionAvoidance SuspicionAvoidance `yaml:"suspicion_avoidance"`
 	DMonReact          DMonReact          `yaml:"dm_on_react"`
+}
+
+type RaidSettings struct {
+	Delay                 int    `yaml:"individual_delay"`
+	LongDelay             int    `yaml:"rate_limit_delay"`
+	Offset                int    `yaml:"offset"`
+	RandomIndividualDelay int    `yaml:"random_individual_delay"`
+	Skip                  bool   `yaml:"skip_completed"`
+	OnlineTokens          bool   `yaml:"online_tokens"`
+	DuplicateMessage      bool   `yaml:"duplicate_message"`
+	WatcherToken          string `yaml:"watcher_token"`
+	InviteLink            string `yaml:"invite_link"`
+	VerifyChannelId       string `yaml:"verify_channel_id"`
+	VerifyMessageId       string `yaml:"verify_message_id"`
+	AttackedChannel       string `yaml:"attacked_channel"`
+	AttackedServer        string `yaml:"attacked_server"`
 }
 
 type DirectMessage struct {

--- a/instance/headers.go
+++ b/instance/headers.go
@@ -8,6 +8,7 @@ package instance
 
 import (
 	"fmt"
+	"github.com/V4NSH4J/discord-mass-dm-GO/utilities"
 	"net/http"
 )
 
@@ -202,7 +203,14 @@ func (in *Instance) OpenChannelHeaders(req *http.Request, cookie string) *http.R
 	return req
 }
 
-func (in *Instance) SendMessageHeaders(req *http.Request, cookie, recipient string) *http.Request {
+func (in *Instance) SendMessageHeaders(req *http.Request, cookie string, params utilities.SnowflakeParams) *http.Request {
+	var referer string
+	if params.ChannelId != "" {
+		referer = fmt.Sprintf(`https://discord.com/channels/%s/%s`, params.ServerId, params.ChannelId)
+	} else {
+		referer = fmt.Sprintf(`https://discord.com/channels/@me/%s`, params.UserId)
+	}
+
 	if in.Config.OtherSettings.Mode == 2 {
 		for k, v := range map[string]string{
 			"Host":               "discord.com",
@@ -227,7 +235,7 @@ func (in *Instance) SendMessageHeaders(req *http.Request, cookie, recipient stri
 			"content-type":         "application/json",
 			"cookie":               cookie,
 			"origin":               "https://discord.com",
-			"referer":              fmt.Sprintf("https://discord.com/channels/@me/%s", recipient),
+			"referer":              referer,
 			"sec-ch-ua":            `".Not/A)Brand";v="99", "Google Chrome";v="103", "Chromium";v="103"`,
 			"sec-ch-ua-mobile":     "?0",
 			"sec-ch-ua-platform":   `"Windows"`,
@@ -248,7 +256,14 @@ func (in *Instance) SendMessageHeaders(req *http.Request, cookie, recipient stri
 	return req
 }
 
-func (in *Instance) TypingHeaders(req *http.Request, cookie, snowflake string) *http.Request {
+func (in *Instance) TypingHeaders(req *http.Request, cookie string, params utilities.SnowflakeParams) *http.Request {
+	var referer string
+	if params.ChannelId != "" {
+		referer = fmt.Sprintf(`https://discord.com/channels/%s/%s`, params.ServerId, params.ChannelId)
+	} else {
+		referer = fmt.Sprintf(`https://discord.com/channels/@me/%s`, params.UserId)
+	}
+
 	if in.Config.OtherSettings.Mode == 2 {
 		for k, v := range map[string]string{
 			"Host":               "discord.com",
@@ -271,7 +286,7 @@ func (in *Instance) TypingHeaders(req *http.Request, cookie, snowflake string) *
 			"content-type":         "application/json",
 			"cookie":               cookie,
 			"origin":               "https://discord.com",
-			"referer":              fmt.Sprintf("https://discord.com/channels/@me/%s", snowflake),
+			"referer":              referer,
 			"sec-ch-ua":            `".Not/A)Brand";v="99", "Google Chrome";v="103", "Chromium";v="103"`,
 			"sec-ch-ua-mobile":     "?0",
 			"sec-ch-ua-platform":   `"Windows"`,

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 
 // Options menu
 func Options() {
-	utilities.PrintMenu([]string{"Invite Joiner", "Mass DM", "Single DM", "Reaction Adder", "Email:Password:Token to Token", "Token Checker", "Guild Leaver", "Token Onliner", "Scraping Menu", "Name Changer", "Avatar Changer", "Token Server Checker", "Bio Changer", "DM on Reaction", "Hypesquad Changer", "Token Password Changer", "Embed Maker", "Login into Token", "Token Nuker", "Button Presser", "Server Nickname Changer", "Friend Request Spammer", "Friends Mass DM [BETA]","Credits & Help", "Exit"})
+	utilities.PrintMenu([]string{"Invite Joiner", "Mass DM", "Raid Server", "Single DM", "Reaction Adder", "Email:Password:Token to Token", "Token Checker", "Guild Leaver", "Token Onliner", "Scraping Menu", "Name Changer", "Avatar Changer", "Token Server Checker", "Bio Changer", "DM on Reaction", "Hypesquad Changer", "Token Password Changer", "Embed Maker", "Login into Token", "Token Nuker", "Button Presser", "Server Nickname Changer", "Friend Request Spammer", "Friends Mass DM [BETA]", "Credits & Help", "Exit"})
 	choice := utilities.UserInputInteger("Enter your choice!")
 	switch choice {
 	default:
@@ -40,71 +40,74 @@ func Options() {
 		color.Cyan.Printf("Mass DM advertiser\n")
 		discord.LaunchMassDM()
 	case 3:
+		color.Cyan.Printf("Raid Server\n")
+		discord.LaunchRaidServer()
+	case 4:
 		color.Cyan.Printf("Single DM spam\n")
 		discord.LaunchSingleDM()
-	case 4:
+	case 5:
 		color.Cyan.Printf("Reaction Adder\n")
 		discord.LaunchReactionAdder()
-	case 5:
+	case 6:
 		color.Cyan.Printf("Email:Pass:Token to Token\n")
 		discord.LaunchTokenFormatter()
-	case 6:
+	case 7:
 		color.Cyan.Printf("Token Checker\n")
 		discord.LaunchTokenChecker()
-	case 7:
+	case 8:
 		color.Cyan.Printf("Guild Leaver\n")
 		discord.LaunchGuildLeaver()
-	case 8:
+	case 9:
 		color.Cyan.Printf("Token Onliner\n")
 		discord.LaunchTokenOnliner()
-	case 9:
+	case 10:
 		color.Cyan.Printf("Scraping Menu\n")
 		discord.LaunchScraperMenu()
-	case 10:
+	case 11:
 		color.Cyan.Printf("Name Changer\n")
 		discord.LaunchNameChanger()
-	case 11:
+	case 12:
 		color.Cyan.Printf("Profile Picture Changer\n")
 		discord.LaunchAvatarChanger()
-	case 12:
+	case 13:
 		color.Cyan.Printf("Token Servers Check\n")
 		discord.LaunchServerChecker()
-	case 13:
+	case 14:
 		color.Cyan.Printf("Bio Changer\n")
 		discord.LaunchBioChanger()
-	case 14:
+	case 15:
 		color.Cyan.Printf("DM on React\n")
 		discord.LaunchDMReact()
-	case 15:
+	case 16:
 		color.Cyan.Printf("Hypesquad Changer\n")
 		discord.LaunchHypeSquadChanger()
-	case 16:
+	case 17:
 		color.Cyan.Printf("Mass token changer\n")
 		discord.LaunchTokenChanger()
-	case 17:
+	case 18:
 		color.Cyan.Printf("Create Embed\n")
 		discord.LanuchEmbed()
-	case 18:
+	case 19:
 		color.Cyan.Printf("Login into Token\n")
 		discord.LaunchTokenLogin()
-	case 19:
+	case 20:
 		color.Cyan.Printf("Token Nuker\n")
 		discord.LaunchTokenNuker()
-	case 20:
+	case 21:
 		color.Cyan.Printf("Button Press\n")
 		discord.LaunchButtonClicker()
-	case 21:
+	case 22:
 		color.Cyan.Printf("Server Nickname Changer\n")
 		discord.LaunchServerNicknameChanger()
-	case 22:
+	case 23:
 		color.Cyan.Printf("Friend Request Spammer\n")
 		discord.LaunchFriendRequestSpammer()
-	case 23:
+	case 24:
 		color.Cyan.Printf("Friends Mass DM\n")
 		discord.LaunchFriendSpammer()
-	case 24:
-		color.Blue.Printf("Made with <3 by github.com/V4NSH4J - Check out the github page for detailed documentation\n")
 	case 25:
+		color.Blue.Printf("Made with <3 by github.com/V4NSH4J - Check out the github page for detailed documentation\n")
+	case 26:
 		os.Exit(0)
 	}
 	time.Sleep(1 * time.Second)

--- a/utilities/misc.go
+++ b/utilities/misc.go
@@ -59,6 +59,19 @@ func Contains(s []string, e string) bool {
 	return false
 }
 
+func ContainsInt(s []int, e int) bool {
+	defer HandleOutOfBounds()
+	if len(s) == 0 {
+		return false
+	}
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
 // Inputs 2 slices of strings and returns a slice of strings which does not contain elements from the second slice
 func RemoveSubset(s []string, r []string) []string {
 	var n []string
@@ -182,6 +195,14 @@ func TimeDifference(t1, t2 time.Time) string {
 	hours := remainderDays * 24
 	intHours := int(hours)
 	return fmt.Sprintf("%v years, %v months, %v days, %v hours", intYears, intMonths, intDays, intHours)
+}
+
+func GetConfigOrInputString(config string, message string) string {
+	if len(config) > 0 {
+		return config
+	} else {
+		return UserInput(message)
+	}
 }
 
 func isNewer(check string, current string) bool {

--- a/utilities/snowflake_params.go
+++ b/utilities/snowflake_params.go
@@ -1,0 +1,5 @@
+package utilities
+
+type SnowflakeParams struct {
+	UserId, ChannelId, ServerId string
+}


### PR DESCRIPTION
Well this is my take on a basic raiding functionality (_didn't want to pay for some s*** closed-source software_)

I'm new to Go and as such my code is not going to be as clean as I wanted it to - I heavily copy pasted existing code whilst changing a few small details. It's also my first time contributing to an open-source project, so go easy on me.

I conducted several successful Raids using this variation (people actually congratulated us 💯, thought we were real thanks to Suspicion Avoidance)

The flow would be like this: 
1. Set up the config.yml for maximum efficency (_it's the reason I included some options there_)
2. Invite Joiner -> Raid Mode -> No Verification (I couldn't get this to work)
3. Reaction Adder -> Verify Mode (make sure to set Watcher Token) -> Choose Emoji
4. Raid Server -> From message or file
5. Reaction Adder *optional - we usually added another message as a final blow and had the bots react on it -> it should only prompt for final message ID if configured correctly

One improvement would be to have all of this part of one command: Raid Server -> after every token is done joining they should wait for their commander to give the signal to verify and then to Raid Channel

